### PR TITLE
Add translations to the add-react-to-a-website page

### DIFF
--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -8,28 +8,29 @@ prev: getting-started.html
 next: create-a-new-react-app.html
 ---
 
-Use as little or as much React as you need.
+Use o mínimo ou o máximo de React que precisar.
 
-React has been designed from the start for gradual adoption, and **you can use as little or as much React as you need**. Perhaps you only want to add some "sprinkles of interactivity" to an existing page. React components are a great way to do that.
+O React foi desenvolvido desde o início para uma adoção gradual, e **podes usar o mínimo ou o máximo de React que precisares**
+Talves só precisas de adicionar uma "pitada de interactividade" a um projeto existente. Os componente de React são uma excelente maneira para fazer isso.
 
-The majority of websites aren't, and don't need to be, single-page apps. With **a few lines of code and no build tooling**, try React in a small part of your website. You can then either gradually expand its presence, or keep it contained to a few dynamic widgets.
+A maior parte das páginas web não são, e não precisam de ser aplicações single-page. Com **algumas linhas de código e sem build tools**, experimente React numa pequena parte da sua página web. Depois poderás expandir a sua presença, ou manter-la contida em alguns widgets.
 
 ---
 
-- [Add React in One Minute](#add-react-in-one-minute)
-- [Optional: Try React with JSX](#optional-try-react-with-jsx) (no bundler necessary!)
+- [Adiciona React num minuto](#add-react-in-one-minute)
+- [Opcional: Experimente React com JSX](#optional-try-react-with-jsx) (não precisa de bundler!)
 
-## Add React in One Minute {#add-react-in-one-minute}
+## Adiciona React num minuto {#add-react-in-one-minute}
 
-In this section, we will show how to add a React component to an existing HTML page. You can follow along with your own website, or create an empty HTML file to practice.
+Nesta secção, vamos mostrar como adicionar um componente de React a uma existente página web. Poderás seguir com a tua página web ou criar um projeto HTML vazio para praticar.
 
-There will be no complicated tools or install requirements -- **to complete this section, you only need an internet connection, and a minute of your time.**
+Não serão necessarias ferramentas complicadas ou instalações -- **para completares esta secção, só precisas de uma conecção à internet e um minuto do teu tempo.**
 
-Optional: [Download the full example (2KB zipped)](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605/archive/f6c882b6ae18bde42dcf6fdb751aae93495a2275.zip)
+Opcional: [Faça Download do exemplo completo (2KB zipped)](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605/archive/f6c882b6ae18bde42dcf6fdb751aae93495a2275.zip)
 
-### Step 1: Add a DOM Container to the HTML {#step-1-add-a-dom-container-to-the-html}
+### Passo 1: Adiciona o contentor DOM ao HTML {#step-1-add-a-dom-container-to-the-html}
 
-First, open the HTML page you want to edit. Add an empty `<div>` tag to mark the spot where you want to display something with React. For example:
+Primeiro abre uma página HTML que queira editar. Adiciona uma tag `<div>` que será usada para mostrar algo usando React. Por exemplo:
 
 ```html{3}
 <!-- ... existing HTML ... -->
@@ -39,11 +40,11 @@ First, open the HTML page you want to edit. Add an empty `<div>` tag to mark the
 <!-- ... existing HTML ... -->
 ```
 
-We gave this `<div>` a unique `id` HTML attribute. This will allow us to find it from the JavaScript code later and display a React component inside of it.
+Adicionamos a esta tag `<div>` um atributo `id` único. Que fará com que o código JavaScript o encontre mais tarde onde irá mostrar dentro o componente React.
 
->Tip
+>Dica
 >
->You can place a "container" `<div>` like this **anywhere** inside the `<body>` tag. You may have as many independent DOM containers on one page as you need. They are usually empty -- React will replace any existing content inside DOM containers.
+>Poderá colocar um "contentor" como esta tag `<div>` em **qualquer lado** dentro da tag `<body>`. Poderá ter a quantidade de contentores DOM que precisar em uma só página web. Normalmente estão vazios -- React irá substituir qualquer conteudo existente.
 
 ### Step 2: Add the Script Tags {#step-2-add-the-script-tags}
 

--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -26,7 +26,7 @@ Nesta secção, vamos mostrar como adicionar um componente de React a uma existe
 
 Não serão necessarias ferramentas complicadas ou instalações -- **para completares esta secção, só precisas de uma conecção à internet e um minuto do teu tempo.**
 
-Opcional: [Faça Download do exemplo completo (2KB zipped)](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605/archive/f6c882b6ae18bde42dcf6fdb751aae93495a2275.zip)
+Opcional: [Faça Download do exemplo completo (2KB zip)](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605/archive/f6c882b6ae18bde42dcf6fdb751aae93495a2275.zip)
 
 ### Passo 1: Adiciona o contentor DOM ao HTML {#step-1-add-a-dom-container-to-the-html}
 
@@ -46,90 +46,90 @@ Adicionamos a esta tag `<div>` um atributo `id` único. Que fará com que o cód
 >
 >Poderá colocar um "contentor" como esta tag `<div>` em **qualquer lado** dentro da tag `<body>`. Poderá ter a quantidade de contentores DOM que precisar em uma só página web. Normalmente estão vazios -- React irá substituir qualquer conteudo existente.
 
-### Step 2: Add the Script Tags {#step-2-add-the-script-tags}
+### Passo 2: Adicionar as Tags Script {#step-2-add-the-script-tags}
 
-Next, add three `<script>` tags to the HTML page right before the closing `</body>` tag:
+A seguir, adicione três tags `<script>` em sua página HTML logo antes do fechamento da tag `</body>`:
 
 ```html{5,6,9}
-  <!-- ... other HTML ... -->
+  <!-- ...  HTMLHTML qualquer ... -->
 
-  <!-- Load React. -->
-  <!-- Note: when deploying, replace "development.js" with "production.min.js". -->
+  <!-- Adicionar React. -->
+  <!-- Nota: ao fazer o deploy, substitua "development.js" por "production.min.js". -->
   <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script>
 
-  <!-- Load our React component. -->
+  <!-- Adicione nosso componente React. -->
   <script src="like_button.js"></script>
 
 </body>
 ```
 
-The first two tags load React. The third one will load your component code.
+As duas primeiras tags adicionam React. A terceira irá adicionar o código do seu componente.
 
-### Step 3: Create a React Component {#step-3-create-a-react-component}
+### Passo 3: Criar um Componente React {#step-3-create-a-react-component}
 
-Create a file called `like_button.js` next to your HTML page.
+Crie um arquivo chamado `like_button.js` próximo da sua página HTML.
 
-Open **[this starter code](https://gist.github.com/gaearon/0b180827c190fe4fd98b4c7f570ea4a8/raw/b9157ce933c79a4559d2aa9ff3372668cce48de7/LikeButton.js)** and paste it into the file you created.
+Abra **[este código inicial](https://gist.github.com/gaearon/0b180827c190fe4fd98b4c7f570ea4a8/raw/b9157ce933c79a4559d2aa9ff3372668cce48de7/LikeButton.js)** e copie o conteúdo no arquivo que você criou.
 
->Tip
+>Dica
 >
->This code defines a React component called `LikeButton`. Don't worry if you don't understand it yet -- we'll cover the building blocks of React later in our [hands-on tutorial](/tutorial/tutorial.html) and [main concepts guide](/docs/hello-world.html). For now, let's just get it showing on the screen!
+>Este código cria um componente React chamado `LikeButton`. Não se preocupe se não perceber -- mais tarde iremos cobrir os blocos de construção do React [tutorial](/tutorial/tutorial.html) e no [guia dos conceitos principais](/docs/hello-world.html). Por enquanto, vamos apenas fazer funcionar!
 
-After **[the starter code](https://gist.github.com/gaearon/0b180827c190fe4fd98b4c7f570ea4a8/raw/b9157ce933c79a4559d2aa9ff3372668cce48de7/LikeButton.js)**, add two lines to the bottom of `like_button.js`:
+Depois **[do código inicial](https://gist.github.com/gaearon/0b180827c190fe4fd98b4c7f570ea4a8/raw/b9157ce933c79a4559d2aa9ff3372668cce48de7/LikeButton.js)**, adiciona estas duas linhas no fim do `like_button.js`:
 
 ```js{3,4}
-// ... the starter code you pasted ...
+// ... código inicial copiado ...
 
 const domContainer = document.querySelector('#like_button_container');
 ReactDOM.render(e(LikeButton), domContainer);
 ```
 
-These two lines of code find the `<div>` we added to our HTML in the first step, and then display our "Like" button React component inside of it. 
+Essas duas linhas de código encontram a `<div>` que foi adiciona ao HTML no primeiro passo e então mostrará o componente "Like" React dentro dele.
 
-### That's It! {#thats-it}
+### É isso! {#thats-it}
 
-There is no step four. **You have just added the first React component to your website.**
+Não exite quartp passo. **Acabste de adicionar o primeiro componente React a tua página web.**
 
-Check out the next sections for more tips on integrating React.
+Veja as proximas secções para ver mais dicas de como integrar React.
 
-**[View the full example source code](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605)**
+**[Veja o código fonte completo do exemplo](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605)**
 
-**[Download the full example (2KB zipped)](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605/archive/f6c882b6ae18bde42dcf6fdb751aae93495a2275.zip)**
+**[Faça o download do exemplo completo (2KB zip)](https://gist.github.com/gaearon/6668a1f6986742109c00a581ce704605/archive/f6c882b6ae18bde42dcf6fdb751aae93495a2275.zip)**
 
-### Tip: Reuse a Component {#tip-reuse-a-component}
+### Tip: Reutilizar um Componente {#tip-reuse-a-component}
 
-Commonly, you might want to display React components in multiple places on the HTML page. Here is an example that displays the "Like" button three times and passes some data to it:
+Normalmente, quer mostrar um componente React em multiplos sitios na página HTML. Aqui esta um exemplo que mostar o botão "Like" três vezes e passa alguns dados nele:
 
-[View the full example source code](https://gist.github.com/gaearon/faa67b76a6c47adbab04f739cba7ceda)
+[Veja o código fonte completo do exemplo](https://gist.github.com/gaearon/faa67b76a6c47adbab04f739cba7ceda)
 
-[Download the full example (2KB zipped)](https://gist.github.com/gaearon/faa67b76a6c47adbab04f739cba7ceda/archive/9d0dd0ee941fea05fd1357502e5aa348abb84c12.zip)
+[Faça o download do exemplo completo (2KB zip)](https://gist.github.com/gaearon/faa67b76a6c47adbab04f739cba7ceda/archive/9d0dd0ee941fea05fd1357502e5aa348abb84c12.zip)
 
->Note
+>Nota
 >
->This strategy is mostly useful while React-powered parts of the page are isolated from each other. Inside React code, it's easier to use [component composition](/docs/components-and-props.html#composing-components) instead.
+>Esta estratégia é mais útil quando as partes da página com Reactestão isoladas. Dentro do código React, é facil de usar [composição de componentes](/docs/components-and-props.html#composing-components) instead.
 
-### Tip: Minify JavaScript for Production {#tip-minify-javascript-for-production}
+### Nota: Minifique o JavaScript para Produção {#tip-minify-javascript-for-production}
 
-Before deploying your website to production, be mindful that unminified JavaScript can significantly slow down the page for your users.
+Antes de fazer deploy da sua página web para produção, lembre-se que o código JavaScript não minificado pode deixar sua página significativamente mais lenta para seus utilizadores.
 
-If you already minify the application scripts, **your site will be production-ready** if you ensure that the deployed HTML loads the versions of React ending in `production.min.js`:
+Se já minificou os scripts da sua aplicação, seu site estará pronto para produção se garantir que o HTML carregue a versão do React terminando em `production.min.js`:
 
 ```js
 <script src="https://unpkg.com/react@16/umd/react.production.min.js" crossorigin></script>
 <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" crossorigin></script>
 ```
 
-If you don't have a minification step for your scripts, [here's one way to set it up](https://gist.github.com/gaearon/42a2ffa41b8319948f9be4076286e1f3).
+Se não tiver uma versão minificada para os seus scripts, [aqui tem uma forma de o configurar](https://gist.github.com/gaearon/42a2ffa41b8319948f9be4076286e1f3).
 
-## Optional: Try React with JSX {#optional-try-react-with-jsx}
+## Opcional: Experimente React com JSX {#optional-try-react-with-jsx}
 
-In the examples above, we only relied on features that are natively supported by the browsers. This is why we used a JavaScript function call to tell React what to display:
+Nos exemplos acima, contamos apenas com recursos que são suportados nativamente pelos navegadores. E é por isso que usamos uma chamada de função JavaScript para informar ao React o que exibir:
 
 ```js
 const e = React.createElement;
 
-// Display a "Like" <button>
+// Exibe um <button> "Like"
 return e(
   'button',
   { onClick: () => this.setState({ liked: true }) },
@@ -137,10 +137,10 @@ return e(
 );
 ```
 
-However, React also offers an option to use [JSX](/docs/introducing-jsx.html) instead:
+No entanto, como alternativa React tambem oferece uma opção de usar [JSX](/docs/introducing-jsx.html):
 
 ```js
-// Display a "Like" <button>
+// Exibe um <button> "Like"
 return (
   <button onClick={() => this.setState({ liked: true })}>
     Like
@@ -148,56 +148,55 @@ return (
 );
 ```
 
-These two code snippets are equivalent. While **JSX is [completely optional](/docs/react-without-jsx.html)**, many people find it helpful for writing UI code -- both with React and with other libraries.
+Esses dois blocos de código são equivalentes. Enquanto o **JSX é [completamente opcional(/docs/react-without-jsx.html)**, muitas pessoas o acham útil para escrever código de UI — junto com React e com outras bibliotecas.
 
-You can play with JSX using [this online converter](https://babeljs.io/en/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=DwIwrgLhD2B2AEcDCAbAlgYwNYF4DeAFAJTw4B88EAFmgM4B0tAphAMoQCGETBe86WJgBMAXJQBOYJvAC-RGWQBQ8FfAAyaQYuAB6cFDhkgA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2&prettier=false&targets=&version=7.4.3).
+Poderá brincar com JSX usando [este conversor online](https://babeljs.io/en/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=DwIwrgLhD2B2AEcDCAbAlgYwNYF4DeAFAJTw4B88EAFmgM4B0tAphAMoQCGETBe86WJgBMAXJQBOYJvAC-RGWQBQ8FfAAyaQYuAB6cFDhkgA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=es2015%2Creact%2Cstage-2&prettier=false&targets=&version=7.4.3).
 
-### Quickly Try JSX {#quickly-try-jsx}
+### Experimente Rapidamente JSX {#quickly-try-jsx}
 
-The quickest way to try JSX in your project is to add this `<script>` tag to your page:
+A maneira mais rápida de experimentar o JSX em seu projeto é adicionando essa tag `<script>` em sua página:
 
 ```html
 <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
 ```
+Agora poderá usar o JSX em qualquer tag <script> somente adicionando o atributo type="text/babel" nele. Aqui está um exemplo de arquivo HTML com JSX em que poderá efetuar o download e testar.
 
-Now you can use JSX in any `<script>` tag by adding `type="text/babel"` attribute to it. Here is [an example HTML file with JSX](https://raw.githubusercontent.com/reactjs/reactjs.org/master/static/html/single-file-example.html) that you can download and play with.
+Essa abordagem é boa para aprender e criar demostrações simples. No entanto, coloca a página web lenta, não ficando **adequada para produção**. Quando estiver pronto para seguir em frente, remova essa nova tag `<script>` e os atributos `type="text/babel"` que adicionou. Em vez disso, na seção a seguir ira configurar um pré-processador JSX para converter todas suas tags `<script>` automaticamente.
 
-This approach is fine for learning and creating simple demos. However, it makes your website slow and **isn't suitable for production**. When you're ready to move forward, remove this new `<script>` tag and the `type="text/babel"` attributes you've added. Instead, in the next section you will set up a JSX preprocessor to convert all your `<script>` tags automatically.
+### Adicionar JSX a um Projeto {#add-jsx-to-a-project}
 
-### Add JSX to a Project {#add-jsx-to-a-project}
+Adicionar JSX a um projeto não requer ferramentas complicadas, como um empacotador ou um servidor de desenvolvimento. Basicamente, adicionar JSX **é como adicionar um pré-processador CSS.** O único requisito é possuir o [Node.js](https://nodejs.org/) instalado em seu computador.
 
-Adding JSX to a project doesn't require complicated tools like a bundler or a development server. Essentially, adding JSX **is a lot like adding a CSS preprocessor.** The only requirement is to have [Node.js](https://nodejs.org/) installed on your computer.
+No terminal, vá até a pasta do seu projeto e cole esses dois comandos:
 
-Go to your project folder in the terminal, and paste these two commands:
+1. **Passo 1:** Corra `npm init -y` (se falhar, [aqui esta um fix](https://gist.github.com/gaearon/246f6380610e262f8a648e3e51cad40d))
+2. **Passo 2:** Corra `npm install babel-cli@6 babel-preset-react-app@3`
 
-1. **Step 1:** Run `npm init -y` (if it fails, [here's a fix](https://gist.github.com/gaearon/246f6380610e262f8a648e3e51cad40d))
-2. **Step 2:** Run `npm install babel-cli@6 babel-preset-react-app@3`
-
->Tip
+>Dica
 >
->We're **using npm here only to install the JSX preprocessor;** you won't need it for anything else. Both React and the application code can stay as `<script>` tags with no changes.
+>Estamos **a usar npm para isntalar o processador JSX;** não irá precisar dele para mais nada. Tanto o React e o código da aplicação podem ficar com as tags `<script>`.
 
-Congratulations! You just added a **production-ready JSX setup** to your project.
+Parabéns! Acabou de adicionar uma **configuração JSX pronta para produção** em seu projeto.
 
 
-### Run JSX Preprocessor {#run-jsx-preprocessor}
+### Execute o Pré-processador JSX {#run-jsx-preprocessor}
 
-Create a folder called `src` and run this terminal command:
+Crie uma pasta chamada `src` e execute no terminal esse comando:
 
 ```
-npx babel --watch src --out-dir . --presets react-app/prod 
+npx babel --watch src --out-dir . --presets react-app/prod
 ```
 
->Note
+>Nota
 >
->`npx` is not a typo -- it's a [package runner tool that comes with npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
+>`npx` não é um erro de digitação -- é uma [ferramenta de executar pacotes que vem com npm 5.2+](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b).
 >
->If you see an error message saying "You have mistakenly installed the `babel` package", you might have missed [the previous step](#add-jsx-to-a-project). Perform it in the same folder, and then try again.
+>Se vir uma mensagem de erro dizendo “You have mistakenly installed the babel package”, poderá ter perdido o [passo anterior](#add-jsx-to-a-project). Execute o passo anterior na mesma pasta e tente novamente.
 
-Don't wait for it to finish -- this command starts an automated watcher for JSX.
+Não espere o comando finalizar — esse comando inicia um watcher automatizado para o JSX.
 
-If you now create a file called `src/like_button.js` with this **[JSX starter code](https://gist.github.com/gaearon/c8e112dc74ac44aac4f673f2c39d19d1/raw/09b951c86c1bf1116af741fa4664511f2f179f0a/like_button.js)**, the watcher will create a preprocessed `like_button.js` with the plain JavaScript code suitable for the browser. When you edit the source file with JSX, the transform will re-run automatically.
+Se criar um arquivo chamado `src/like_button.js` com este **[código JSX inicial](https://gist.github.com/gaearon/c8e112dc74ac44aac4f673f2c39d19d1/raw/09b951c86c1bf1116af741fa4664511f2f179f0a/like_button.js)**, o watcher criará um  `like_button.js` pré-processado com o código JavaScript adequado ao navegador. Quando editae o arquivo com JSX, a transpilação será executada automaticamente.
 
-As a bonus, this also lets you use modern JavaScript syntax features like classes without worrying about breaking older browsers. The tool we just used is called Babel, and you can learn more about it from [its documentation](https://babeljs.io/docs/en/babel-cli/).
+Como um bônus, isso também permite que use recursos modernos de JavaScript, como classes, sem se preocupar com a incompatibilidade de navegadores antigos. A ferramenta que acabamos de usar é chamada de Babel e pode aprender mais sobre ele [na sua documentação](https://babeljs.io/docs/en/babel-cli/).
 
-If you notice that you're getting comfortable with build tools and want them to do more for you, [the next section](/docs/create-a-new-react-app.html) describes some of the most popular and approachable toolchains. If not -- those script tags will do just fine!
+Se se sentir confortável com ferramentas de build e deseja que eles façam mais por você, a [próxima seção](/docs/create-a-new-react-app.html) descreve alguma das mais populares e acessíveis ferramentas. Caso contrário, essas tags scripts funcionarão perfeitamente.

--- a/examples/uncontrolled-components/input-type-file.js
+++ b/examples/uncontrolled-components/input-type-file.js
@@ -9,9 +9,7 @@ class FileInput extends React.Component {
     // highlight-range{4}
     event.preventDefault();
     alert(
-      `Selected file - ${
-        this.fileInput.current.files[0].name
-      }`
+      `Selected file - ${this.fileInput.current.files[0].name}`
     );
   }
 

--- a/plugins/gatsby-source-react-error-codes/gatsby-node.js
+++ b/plugins/gatsby-source-react-error-codes/gatsby-node.js
@@ -20,9 +20,7 @@ exports.sourceNodes = async ({actions}) => {
     });
   } catch (error) {
     console.error(
-      `The gatsby-source-react-error-codes plugin has failed:\n${
-        error.message
-      }`,
+      `The gatsby-source-react-error-codes plugin has failed:\n${error.message}`,
     );
 
     process.exit(1);

--- a/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
+++ b/plugins/gatsby-transformer-versions-yaml/gatsby-node.js
@@ -20,10 +20,12 @@ exports.onPostBuild = async ({store}) => {
 
   // versions.yml structure is [{path: string, url: string, ...}, ...]
   createRedirects(
-    versions.filter(version => version.path && version.url).map(version => ({
-      fromPath: version.path,
-      toPath: version.url,
-    })),
+    versions
+      .filter(version => version.path && version.url)
+      .map(version => ({
+        fromPath: version.path,
+        toPath: version.url,
+      })),
     redirectsFilePath,
   );
 };

--- a/src/components/LayoutHeader/DocSearch.js
+++ b/src/components/LayoutHeader/DocSearch.js
@@ -27,7 +27,9 @@ class DocSearch extends Component<{}, State> {
         inputSelector: '#algolia-doc-search',
       });
     } else {
-      console.warn('A pesquisa falhou ao ser carregada e agora será desativada');
+      console.warn(
+        'A pesquisa falhou ao ser carregada e agora será desativada',
+      );
       this.setState({enabled: false});
     }
   }

--- a/src/components/MarkdownPage/MarkdownPage.js
+++ b/src/components/MarkdownPage/MarkdownPage.js
@@ -112,9 +112,7 @@ const MarkdownPage = ({
                   <div css={{marginTop: 80}}>
                     <a
                       css={sharedStyles.articleLayout.editLink}
-                      href={`https://github.com/reactjs/pt-pt.reactjs.org/tree/master/${
-                        markdownRemark.fields.path
-                      }`}>
+                      href={`https://github.com/reactjs/pt-pt.reactjs.org/tree/master/${markdownRemark.fields.path}`}>
                       Edite esta página
                     </a>
                   </div>

--- a/src/theme.js
+++ b/src/theme.js
@@ -55,9 +55,7 @@ const media = {
       if (SIZES[largeKey].max === Infinity) {
         return `@media (min-width: ${SIZES[smallKey].min}px)`;
       } else {
-        return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${
-          SIZES[largeKey].max
-        }px)`;
+        return `@media (min-width: ${SIZES[smallKey].min}px) and (max-width: ${SIZES[largeKey].max}px)`;
       }
     }
   },

--- a/src/utils/sectionList.js
+++ b/src/utils/sectionList.js
@@ -12,19 +12,15 @@ import navDocs from '../../content/docs/nav.yml';
 // $FlowExpectedError
 import navTutorial from '../../content/tutorial/nav.yml';
 
-const sectionListDocs = navDocs.map(
-  (item: Object): Object => ({
-    ...item,
-    directory: 'docs',
-  }),
-);
+const sectionListDocs = navDocs.map((item: Object): Object => ({
+  ...item,
+  directory: 'docs',
+}));
 
-const sectionListCommunity = navCommunity.map(
-  (item: Object): Object => ({
-    ...item,
-    directory: 'community',
-  }),
-);
+const sectionListCommunity = navCommunity.map((item: Object): Object => ({
+  ...item,
+  directory: 'community',
+}));
 
 export {
   sectionListCommunity,


### PR DESCRIPTION
This `PR` adds complete portuguese translations to the `add-react-to-a-website` page.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/32181388/189216279-6ad220cf-ffc1-454d-ae2a-5c33bd4f99a1.png">

<img width="1279" alt="image" src="https://user-images.githubusercontent.com/32181388/189216502-6bfbfe51-7428-400e-b683-7483c092861b.png">

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
